### PR TITLE
Update docket image to use a sub directory for cert

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,7 +2,7 @@
 
 if [ ! -z "${RTSP_URL:-}" ] && [ ! -z "${HOST}" ] && [ ! -z "${TOKEN}" ]; then
   echo "Using RTSP streom from $RTSP_URL"
-  exec unifi-cam-proxy --host "$HOST" --name "${NAME:-unifi-cam-proxy}" --mac "${MAC:-'AA:BB:CC:00:11:22'}" --cert /client.pem --token "$TOKEN" rtsp -s "$RTSP_URL"
+  exec unifi-cam-proxy --host "$HOST" --name "${NAME:-unifi-cam-proxy}" --mac "${MAC:-'AA:BB:CC:00:11:22'}" --cert /config/client.pem --token "$TOKEN" rtsp -s "$RTSP_URL"
 fi
 
 exec "$@"


### PR DESCRIPTION
I can't seem to be able to get my cert to work with this docker image so it'd be nice to be able to mount a `/config/` directory that contains the client.pem file