### PR TITLE
Add Reolink NVR camera support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,9 @@ unifi-cam-proxy --host <NVR IP> --mac 'AA:BB:CC:33:44:55' --cert client.pem --to
     ```
     unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> hikvision -u <username> -p <password>
     ```
+
+2. Reolink NVR Cameras (Reolink RLN16-410): Adds motion events
+Note: Camera/channel IDs are zero-based    
+```
+    unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> reolink_nvr -u <username> -p <password> -c <camera_id>
+```

--- a/unifi/cams/__init__.py
+++ b/unifi/cams/__init__.py
@@ -2,3 +2,4 @@ from unifi.cams.frigate import FrigateCam
 from unifi.cams.hikvision import HikvisionCam
 from unifi.cams.lorex import LorexCam
 from unifi.cams.rtsp import RTSPCam
+from unifi.cams.reolink_nvr import ReolinkNVRCam

--- a/unifi/cams/reolink_nvr.py
+++ b/unifi/cams/reolink_nvr.py
@@ -24,16 +24,7 @@ class ReolinkNVRCam(UnifiCamBase):
     async def get_snapshot(self):
         img_file = "{}/screen.jpg".format(self.snapshot_dir)
         url = f"http://{self.args.ip}/api.cgi?cmd=Snap&user={self.args.username}&password={self.args.password}&rs=6PHVjvf0UntSLbyT&channel={self.args.channel}"
-        try:
-            async with aiohttp.request("GET", url) as resp:
-                with open(img_file, "wb") as f:
-                    while True:
-                        chunk = await resp.content.read(1024)
-                        if not chunk:
-                            break
-                        f.write(chunk)
-        except aiohttp.ClientError:
-            self.logger.error("Failed to get snapshot")
+        await self.fetch_to_file(url, img_file)
         return img_file
 
     async def run(self):

--- a/unifi/cams/reolink_nvr.py
+++ b/unifi/cams/reolink_nvr.py
@@ -57,16 +57,12 @@ class ReolinkNVRCam(UnifiCamBase):
                       if json_body[0]["value"]["state"] == 1:
                         if not self.motion_in_progress:
                           self.motion_in_progress = True
-                          self.logger.info(
-                              f"Trigger motion start"
-                          )
+                          self.logger.info("Trigger motion start")
                           await self.trigger_motion_start()
                       elif json_body[0]["value"]["state"] == 0:
                         if self.motion_in_progress:
                           self.motion_in_progress = False
-                          self.logger.info(
-                              f"Trigger motion end"
-                          )
+                          self.logger.info("Trigger motion end")
                           await self.trigger_motion_stop()
 
             except aiohttp.ClientError as err:

--- a/unifi/cams/reolink_nvr.py
+++ b/unifi/cams/reolink_nvr.py
@@ -1,0 +1,76 @@
+import tempfile
+
+import aiohttp
+import json
+
+from yarl import URL
+
+from unifi.cams.base import UnifiCamBase
+
+
+class ReolinkNVRCam(UnifiCamBase):
+    @classmethod
+    def add_parser(self, parser):
+        super(ReolinkNVRCam, self).add_parser(parser)
+        parser.add_argument("--username", "-u", required=True, help="NVR username")
+        parser.add_argument("--password", "-p", required=True, help="NVR password")
+        parser.add_argument("--channel", "-c", required=True, help="NVR camera channel")
+
+    def __init__(self, args, logger=None):
+        super().__init__(args, logger)
+        self.snapshot_dir = tempfile.mkdtemp()
+        self.motion_in_progress = False
+
+    async def get_snapshot(self):
+        img_file = "{}/screen.jpg".format(self.snapshot_dir)
+        url = f"http://{self.args.ip}/api.cgi?cmd=Snap&user={self.args.username}&password={self.args.password}&rs=6PHVjvf0UntSLbyT&channel={self.args.channel}"
+        try:
+            async with aiohttp.request("GET", url) as resp:
+                with open(img_file, "wb") as f:
+                    while True:
+                        chunk = await resp.content.read(1024)
+                        if not chunk:
+                            break
+                        f.write(chunk)
+        except aiohttp.ClientError:
+            self.logger.error("Failed to get snapshot")
+        return img_file
+
+    async def run(self):
+        url = URL(
+            f"http://{self.args.ip}/api.cgi?user={self.args.username}&password={self.args.password}",
+            encoded=True,
+        )
+
+        body = f'[{{ "cmd":"GetMdState", "param":{{ "channel":{self.args.channel} }} }}]'
+        while True:
+            self.logger.info(f"Connecting to motion events API: {url}")
+            try:
+                async with aiohttp.ClientSession(
+                    timeout=aiohttp.ClientTimeout(None)
+                ) as session:
+                  while True:
+                    async with session.post(url, data=body) as resp:
+                      data = await resp.read()
+                      json_body = json.loads(data)
+
+                      if json_body[0]["value"]["state"] == 1:
+                        if not self.motion_in_progress:
+                          self.motion_in_progress = True
+                          self.logger.info(
+                              f"Trigger motion start"
+                          )
+                          await self.trigger_motion_start()
+                      elif json_body[0]["value"]["state"] == 0:
+                        if self.motion_in_progress:
+                          self.motion_in_progress = False
+                          self.logger.info(
+                              f"Trigger motion end"
+                          )
+                          await self.trigger_motion_stop()
+
+            except aiohttp.ClientError as err:
+                self.logger.error(f"Motion API request failed, retrying. Error: {err}")
+
+    def get_stream_source(self, stream_index: str):
+      return f"rtsp://{self.args.username}:{self.args.password}@{self.args.ip}:554//h264Preview_{int(self.args.channel) + 1:02}_main"

--- a/unifi/cams/reolink_nvr.py
+++ b/unifi/cams/reolink_nvr.py
@@ -1,8 +1,7 @@
-import tempfile
-
 import aiohttp
 import json
-
+from pathlib import Path
+import tempfile
 from yarl import URL
 
 from unifi.cams.base import UnifiCamBase
@@ -22,7 +21,7 @@ class ReolinkNVRCam(UnifiCamBase):
         self.motion_in_progress = False
 
     async def get_snapshot(self):
-        img_file = "{}/screen.jpg".format(self.snapshot_dir)
+        img_file = Path(self.snapshot_dir, "screen.jpg")
         url = f"http://{self.args.ip}/api.cgi?cmd=Snap&user={self.args.username}&password={self.args.password}&rs=6PHVjvf0UntSLbyT&channel={self.args.channel}"
         await self.fetch_to_file(url, img_file)
         return img_file

--- a/unifi/main.py
+++ b/unifi/main.py
@@ -93,7 +93,7 @@ def main():
 
     # Preflight checks
     if which("ffmpeg") is None:
-        self.logger.error("ffmpeg is not installed")
+        logger.error("ffmpeg is not installed")
         sys.exit(1)
 
     cam = klass(args, logger)

--- a/unifi/main.py
+++ b/unifi/main.py
@@ -6,14 +6,15 @@ from shutil import which
 
 import coloredlogs
 
-from unifi.cams import FrigateCam, HikvisionCam, LorexCam, RTSPCam
+from unifi.cams import FrigateCam, HikvisionCam, LorexCam, ReolinkNVRCam, RTSPCam
 from unifi.core import Core
 
 CAMS = {
+	"frigate": FrigateCam,
     "hikvision": HikvisionCam,
     "lorex": LorexCam,
+	"reolink_nvr": ReolinkNVRCam,
     "rtsp": RTSPCam,
-    "frigate": FrigateCam,
 }
 
 


### PR DESCRIPTION
- Added support for Reolink NVR cameras for motion events
  - I did not test this with standalone Reolink cameras.  Similar code would likely work but this uses channel IDs and what not, so it wouldn't work out of the box.
- Fixed a crash when trying to log the lack of FFMPEG

~Note: Still testing the video streaming because my Windows environment with FFMPEG was wonky~
Tested with WSL, the changes seem to work!