### PR TITLE
Add support for dahua oem devices

### DIFF
--- a/unifi/cams/__init__.py
+++ b/unifi/cams/__init__.py
@@ -1,7 +1,7 @@
+from unifi.cams.dahua import DahuaCam
 from unifi.cams.frigate import FrigateCam
 from unifi.cams.hikvision import HikvisionCam
-from unifi.cams.lorex import LorexCam
 from unifi.cams.reolink_nvr import ReolinkNVRCam
 from unifi.cams.rtsp import RTSPCam
 
-__all__ = ["FrigateCam", "HikvisionCam", "LorexCam", "RTSPCam", "ReolinkNVRCam"]
+__all__ = ["FrigateCam", "HikvisionCam", "DahuaCam", "RTSPCam", "ReolinkNVRCam"]

--- a/unifi/cams/dahua.py
+++ b/unifi/cams/dahua.py
@@ -9,27 +9,79 @@ from yarl import URL
 from unifi.cams.base import UnifiCamBase
 
 
-class LorexCam(UnifiCamBase):
+class DahuaCam(UnifiCamBase):
     def __init__(self, args: argparse.Namespace, logger: logging.Logger) -> None:
         super().__init__(args, logger)
         self.snapshot_dir = tempfile.mkdtemp()
+        if self.args.snapshot_channel is None:
+            self.args.snapshot_channel = self.args.channel - 1
+        if self.args.motion_index is None:
+            self.args.motion_index = self.args.snapshot_channel
 
     @classmethod
     def add_parser(cls, parser: argparse.ArgumentParser) -> None:
         super().add_parser(parser)
-        parser.add_argument("--username", "-u", required=True, help="Camera username")
-        parser.add_argument("--password", "-p", required=True, help="Camera password")
+        parser.add_argument(
+            "--username",
+            "-u",
+            required=True,
+            help="Camera username",
+        )
+        parser.add_argument(
+            "--password",
+            "-p",
+            required=True,
+            help="Camera password",
+        )
+        parser.add_argument(
+            "--channel",
+            "-c",
+            required=False,
+            type=int,
+            default=1,
+            help="Camera channel",
+        )
+        parser.add_argument(
+            "--snapshot-channel",
+            required=False,
+            type=int,
+            default=None,
+            help="Snapshot channel",
+        )
+        parser.add_argument(
+            "--main-stream",
+            required=False,
+            type=int,
+            default=0,
+            help="Main Stream subtype index",
+        )
+        parser.add_argument(
+            "--sub-stream",
+            required=False,
+            type=int,
+            default=1,
+            help="Sub Stream subtype index",
+        )
+        parser.add_argument(
+            "--motion-index",
+            required=False,
+            type=int,
+            default=None,
+            help="VideoMotion event index",
+        )
 
     async def get_snapshot(self) -> Path:
         img_file = Path(self.snapshot_dir, "screen.jpg")
         url = (
             f"http://{self.args.username}:{self.args.password}@{self.args.ip}"
-            f"/cgi-bin/snapshot.cgi"
+            f"/cgi-bin/snapshot.cgi?channel={self.args.snapshot_channel}"
         )
         await self.fetch_to_file(url, img_file)
         return img_file
 
     async def run(self) -> None:
+        if self.args.motion_index == -1:
+            return
         url = (
             f"http://{self.args.username}:{self.args.password}@{self.args.ip}"
             "/cgi-bin/eventManager.cgi?action=attach&codes=[VideoMotion]"
@@ -51,6 +103,8 @@ class LorexCam(UnifiCamBase):
                                 parts = line.split(";")
                                 action = parts[1].split("=")[1].strip()
                                 index = parts[2].split("=")[1].strip()
+                                if index != f"{self.args.motion_index}":
+                                    continue
                                 if action == "Start":
                                     self.logger.info(
                                         f"Trigger motion start for index {index}"
@@ -65,11 +119,13 @@ class LorexCam(UnifiCamBase):
                 self.logger.error("Motion API request failed, retrying")
 
     def get_stream_source(self, stream_index: str) -> str:
-        channel = 0
-        if stream_index != "video1":
-            channel = 2
+
+        if stream_index == "video1":
+            subtype = self.args.main_stream
+        else:
+            subtype = self.args.sub_stream
 
         return (
             f"rtsp://{self.args.username}:{self.args.password}@{self.args.ip}"
-            f"/cam/realmonitor?channel=1&subtype={channel}"
+            f"/cam/realmonitor?channel={self.args.channel}&subtype={subtype}"
         )

--- a/unifi/main.py
+++ b/unifi/main.py
@@ -6,14 +6,15 @@ from shutil import which
 
 import coloredlogs
 
-from unifi.cams import FrigateCam, HikvisionCam, LorexCam, ReolinkNVRCam, RTSPCam
+from unifi.cams import DahuaCam, FrigateCam, HikvisionCam, ReolinkNVRCam, RTSPCam
 from unifi.core import Core
 from unifi.version import __version__
 
 CAMS = {
     "frigate": FrigateCam,
     "hikvision": HikvisionCam,
-    "lorex": LorexCam,
+    "lorex": DahuaCam,
+    "dahua": DahuaCam,
     "reolink_nvr": ReolinkNVRCam,
     "rtsp": RTSPCam,
 }


### PR DESCRIPTION
I'd like to get your feedback on this @keshavdv.

It's working for me on a honeywell HQA nvr, which is a dahua oem device, with the custom ffmpeg args for live view.

I believe lorex also uses dahua which is why the code is so similar.

Perhaps the current lorex support and this one should be merged into a single cam type.