### PR TITLE
Support for Frigate zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,6 @@ unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> lor
 #### Frigate: Supports smart detections
   * Note: Do not use the RTMP stream from frigate, use the original RTSP stream from your camera
 ```
-unifi-cam-proxy  -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token>  frigate -s <rtsp source> --mqtt-host <mqtt host> --frigate-camera <Name of camera in frigate>
+unifi-cam-proxy  -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token>  frigate -s <rtsp source> --mqtt-host <mqtt host> --frigate-host <frigate host> --frigate-camera <Name of camera in frigate>
 
 ```

--- a/unifi/cams/base.py
+++ b/unifi/cams/base.py
@@ -105,7 +105,7 @@ class UnifiCamBase(metaclass=ABCMeta):
 
     # API for subclasses
     async def trigger_motion_start(
-        self, object_type: Optional[SmartDetectObjectType] = None
+        self, object_type: Optional[SmartDetectObjectType] = None, motion_start=int(round(time.time() * 1000))
     ) -> None:
         if not self._motion_event_ts:
             payload: Dict[str, Any] = {
@@ -114,7 +114,7 @@ class UnifiCamBase(metaclass=ABCMeta):
                 "clockMonotonic": int(self.get_uptime()),
                 "clockStream": int(self.get_uptime()),
                 "clockStreamRate": 1000,
-                "clockWall": int(round(time.time() * 1000)),
+                "clockWall": motion_start,
                 "edgeType": "start",
                 "eventId": self._motion_event_id,
                 "eventType": "motion",

--- a/unifi/cams/base.py
+++ b/unifi/cams/base.py
@@ -139,7 +139,7 @@ class UnifiCamBase(metaclass=ABCMeta):
                     payload=payload,
                 ),
             )
-            self._motion_event_ts = time.time()
+            self._motion_event_ts = motion_start
 
             # Capture snapshot at beginning of motion event for thumbnail
             motion_snapshot_path: str = tempfile.NamedTemporaryFile(delete=False).name
@@ -151,17 +151,17 @@ class UnifiCamBase(metaclass=ABCMeta):
                 pass
 
     async def trigger_motion_stop(
-        self, object_type: Optional[SmartDetectObjectType] = None
+        self, object_type: Optional[SmartDetectObjectType] = None, motion_stop=int(round(time.time() * 1000))
     ) -> None:
         motion_start_ts = self._motion_event_ts
         if motion_start_ts:
             payload: Dict[str, Any] = {
                 "clockBestMonotonic": int(self.get_uptime()),
-                "clockBestWall": int(round(motion_start_ts * 1000)),
+                "clockBestWall": motion_start_ts,
                 "clockMonotonic": int(self.get_uptime()),
                 "clockStream": int(self.get_uptime()),
                 "clockStreamRate": 1000,
-                "clockWall": int(round(time.time() * 1000)),
+                "clockWall": motion_stop,
                 "edgeType": "stop",
                 "eventId": self._motion_event_id,
                 "eventType": "motion",

--- a/unifi/cams/frigate.py
+++ b/unifi/cams/frigate.py
@@ -98,18 +98,18 @@ class FrigateCam(RTSPCam):
                     if not frigate_msg["after"]["camera"] == self.args.frigate_camera:
                         continue
 
-                    if (
-                        self.args.frigate_zone
-                    ):
-                        if not self.args.frigate_zone in frigate_msg["after"]["entered_zones"]:
-                            continue
-
                     label = frigate_msg["after"]["label"]
                     object_type = self.label_to_object_type(label)
                     if not object_type:
                         self.logger.warning(
                             f"Received unsupport detection label type: {label}"
                         )
+
+                    if (
+                        self.args.frigate_zone
+                    ):
+                        if self.args.frigate_zone not in frigate_msg["after"]["entered_zones"]:
+                            object_type = None
 
                     if not self.event_id and frigate_msg["type"] == "new":
                         self.event_id = frigate_msg["after"]["id"]

--- a/unifi/cams/frigate.py
+++ b/unifi/cams/frigate.py
@@ -36,6 +36,11 @@ class FrigateCam(RTSPCam):
             type=str,
             help="Name of camera in frigate",
         )
+        parser.add_argument(
+            "--frigate-zone",
+            type=str,
+            help="Name of zone in frigate",
+        )
 
     def get_feature_flags(self) -> Dict[str, Any]:
         return {
@@ -92,6 +97,12 @@ class FrigateCam(RTSPCam):
                     frigate_msg = json.loads(message.payload.decode())
                     if not frigate_msg["after"]["camera"] == self.args.frigate_camera:
                         continue
+
+                    if (
+                        self.args.frigate_zone
+                    ):
+                        if not self.args.frigate_zone in frigate_msg["after"]["entered_zones"]:
+                            continue
 
                     label = frigate_msg["after"]["label"]
                     object_type = self.label_to_object_type(label)


### PR DESCRIPTION
1. Allows setting a --frigate-zone parameter to only flag events when an object is within a particular area, e.g. a person in a driveway. When this parameter is set, motion outside of the zone will be flagged as regular motion instead of a person/vehicle event.
2. Events are now created based on Frigate's start and end times
3. A new --frigate-host parameter fetches event snapshots from the Frigate API instead of using MQTT. This is much more reliable, in my testing, and the snapshots now match what we see in Frigate.

I'm not a Python developer, and so the code might not all be as elegant as I'd like it to be.
The end result however is a marked improvement, at least for my use case.