### PR TITLE
docker multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
-FROM python:3.7
-WORKDIR /app
+# syntax=docker/dockerfile:1.2
+FROM python:3.9-alpine as build
+WORKDIR /build
+# any dependencies in python which requires a compiled c/c++ code (if any)
+RUN apk add --update gcc libc-dev linux-headers libusb-dev
+RUN --mount=target=. \
+    pip3 install --prefix=/srv/unifi-cam-proxy . && find /srv/unifi-cam-proxy
 
-RUN apt-get -y update && apt-get install -y \
-  ffmpeg \
-  netcat-openbsd
+FROM python:3.9-alpine
+WORKDIR /srv/unifi-cam-proxy
+ENV PYTHONPATH="/srv/unifi-cam-proxy/lib/python3.9/site-packages"
+ENV PATH="$PATH:/srv/unifi-cam-proxy/bin"
 
-COPY . .
-
-RUN pip install .
-
+RUN apk add --update ffmpeg netcat-openbsd
+COPY --from=build /srv/unifi-cam-proxy .
 COPY ./docker/entrypoint.sh /
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Hello,

Here is a multi-stage Dockerfile. It reduce the container image to ~100MB.
Tested on Rpi 4 and Rpi 2.

On Rpi 2, I've got this issue (with this image and yours) :
```
Fatal Python error: init_interp_main: can't initialize time
Python runtime state: core initialized
PermissionError: [Errno 1] Operation not permitted

Current thread 0x76f69390 (most recent call first):
<no Python frame>
```
Solved with :
```
docker run --security-opt seccomp=unconfined [...]
```

Thanks for this proxy !