### PR TITLE
Reolink standalone cams work

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,13 @@ unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> hik
 * Standalone cameras
     * Tested: RLC-410-5MP 
 ```
-unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> rtsp -s <rtsp stream> --ffmpeg-args '-c:v copy -vbsf "h264_metadata=tick_rate=60000/1001:fixed_frame_rate_flag=1" -ar 32000 -ac 2 -codec:a aac -b:a 32k'
+unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> rtsp -s <rtsp stream> --ffmpeg-args='-c:v copy -bsf:v "h264_metadata=tick_rate=60000/1001:fixed_frame_rate_flag=1" -ar 32000 -ac 2 -codec:a aac -b:a 32k'
+
 ```
-* Standalone cameras using proper Snapshot URL and Motion-Det API url *work in progress*
+* Standalone cameras using proper Snapshot URL and Motion-Det API url using Camera channel (0 for main 1 for sub) *work in progress*
 ```
-unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> reolink -u <username> -p <password> -c <camera_id>
+unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> reolink -u <username> -p <password> -c <channel id> --ffmpeg-args='-c:v copy -bsf:v "h264_metadata=tick_rate=60000/1001:fixed_frame_rate_flag=1" -ar 32000 -ac 2 -codec:a aac -b:a 32k'
+
 ```
 * NVR (Note: Camera/channel IDs are zero-based)
 ```

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> reo
 ```
 Sub camera stream example
 ```
-unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> reolink -u <username> -p <password> -s sub --ffmpeg-args='-c:v copy -bsf:v "h264_metadata=tick_rate=30000/1001:fixed_frame_rate_flag=1" -ar 32000 -ac 2 -codec:a aac -b:a 32k'
+unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> reolink -u <username> -p <password> -s sub --ffmpeg-args='-c:v copy -bsf:v "h264_metadata=tick_rate=30000/1001:fixed_frame_rate_flag=1" -an'
 ```
 * (Note: Camera/channel arguments are either -s main, or -s sub. The substream is limited to a maximum 15fps so note the tick_rate in the example)
 

--- a/README.md
+++ b/README.md
@@ -83,11 +83,19 @@ unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> hik
 unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> rtsp -s <rtsp stream> --ffmpeg-args='-c:v copy -bsf:v "h264_metadata=tick_rate=60000/1001:fixed_frame_rate_flag=1" -ar 32000 -ac 2 -codec:a aac -b:a 32k'
 
 ```
-* Standalone cameras using proper Snapshot URL and Motion-Det API url using Camera channel (0 for main 1 for sub) *work in progress*
-```
-unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> reolink -u <username> -p <password> -c <channel id> --ffmpeg-args='-c:v copy -bsf:v "h264_metadata=tick_rate=60000/1001:fixed_frame_rate_flag=1" -ar 32000 -ac 2 -codec:a aac -b:a 32k'
+* Standalone cameras using proper Snapshot URL and Motion-Det API url using Camera Substream (main or sub) *work in progress*
 
+Main camera stream example
 ```
+unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> reolink -u <username> -p <password> -s main --ffmpeg-args='-c:v copy -bsf:v "h264_metadata=tick_rate=60000/1001:fixed_frame_rate_flag=1" -ar 32000 -ac 2 -codec:a aac -b:a 32k'
+```
+Sub camera stream example
+```
+unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> reolink -u <username> -p <password> -s sub --ffmpeg-args='-c:v copy -bsf:v "h264_metadata=tick_rate=30000/1001:fixed_frame_rate_flag=1" -ar 32000 -ac 2 -codec:a aac -b:a 32k'
+```
+* (Note: Camera/channel arguments are either -s main, or -s sub. The substream is limited to a maximum 15fps so note the tick_rate in the example)
+
+Reolink NVR
 * NVR (Note: Camera/channel IDs are zero-based)
 ```
 unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> reolink_nvr -u <username> -p <password> -c <camera_id>

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> reo
 ```
 Sub camera stream example
 ```
-unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> reolink -u <username> -p <password> -s sub --ffmpeg-args='-c:v copy -bsf:v "h264_metadata=tick_rate=30000/1001:fixed_frame_rate_flag=1" -an'
+unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> reolink -u <username> -p <password> -s sub --ffmpeg-args='-c:v copy -bsf:v "h264_metadata=tick_rate=30000/1001:fixed_frame_rate_flag=1" -ar 32000 -ac 2 -codec:a aac -b:a 32k'
 ```
 * (Note: Camera/channel arguments are either -s main, or -s sub. The substream is limited to a maximum 15fps so note the tick_rate in the example)
 

--- a/README.md
+++ b/README.md
@@ -78,11 +78,14 @@ unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> hik
 
 #### Reolink:
 * Standalone cameras
-    * Tested: RLC-410-5MP
+    * Tested: RLC-410-5MP 
 ```
 unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> rtsp -s <rtsp stream> --ffmpeg-args '-c:v copy -vbsf "h264_metadata=tick_rate=60000/1001:fixed_frame_rate_flag=1" -ar 32000 -ac 2 -codec:a aac -b:a 32k'
 ```
-
+* Standalone cameras using proper Snapshot URL and Motion-Det API url *work in progress*
+```
+unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> reolink -u <username> -p <password> -c <camera_id>
+```
 * NVR (Note: Camera/channel IDs are zero-based)
 ```
 unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> reolink_nvr -u <username> -p <password> -c <camera_id>

--- a/unifi/cams/__init__.py
+++ b/unifi/cams/__init__.py
@@ -1,7 +1,8 @@
 from unifi.cams.dahua import DahuaCam
 from unifi.cams.frigate import FrigateCam
 from unifi.cams.hikvision import HikvisionCam
+from unifi.cams.reolink import Reolink
 from unifi.cams.reolink_nvr import ReolinkNVRCam
 from unifi.cams.rtsp import RTSPCam
 
-__all__ = ["FrigateCam", "HikvisionCam", "DahuaCam", "RTSPCam", "ReolinkNVRCam"]
+__all__ = ["FrigateCam", "HikvisionCam", "DahuaCam", "RTSPCam", "Reolink", "ReolinkNVRCam"]

--- a/unifi/cams/__init__.py
+++ b/unifi/cams/__init__.py
@@ -5,4 +5,5 @@ from unifi.cams.reolink import Reolink
 from unifi.cams.reolink_nvr import ReolinkNVRCam
 from unifi.cams.rtsp import RTSPCam
 
-__all__ = ["FrigateCam", "HikvisionCam", "DahuaCam", "RTSPCam", "Reolink", "ReolinkNVRCam"]
+__all__ = ["FrigateCam", "HikvisionCam", "DahuaCam",
+           "RTSPCam", "Reolink", "ReolinkNVRCam"]

--- a/unifi/cams/base.py
+++ b/unifi/cams/base.py
@@ -132,7 +132,8 @@ class UnifiCamBase(metaclass=ABCMeta):
                     }
                 )
 
-            self.logger.info(f"Triggering motion start (idx: {self._motion_event_id})")
+            self.logger.info(
+                f"Triggering motion start (idx: {self._motion_event_id})")
             await self.send(
                 self.gen_response(
                     "EventSmartDetect" if object_type else "EventAnalytics",
@@ -142,10 +143,12 @@ class UnifiCamBase(metaclass=ABCMeta):
             self._motion_event_ts = time.time()
 
             # Capture snapshot at beginning of motion event for thumbnail
-            motion_snapshot_path: str = tempfile.NamedTemporaryFile(delete=False).name
+            motion_snapshot_path: str = tempfile.NamedTemporaryFile(
+                delete=False).name
             try:
                 shutil.copyfile(await self.get_snapshot(), motion_snapshot_path)
-                self.logger.debug(f"Captured motion snapshot to {motion_snapshot_path}")
+                self.logger.debug(
+                    f"Captured motion snapshot to {motion_snapshot_path}")
                 self._motion_snapshot = Path(motion_snapshot_path)
             except FileNotFoundError:
                 pass
@@ -178,7 +181,8 @@ class UnifiCamBase(metaclass=ABCMeta):
                         "smartDetectSnapshot": "motionsnap.jpg",
                     }
                 )
-            self.logger.info(f"Triggering motion stop (idx: {self._motion_event_id})")
+            self.logger.info(
+                f"Triggering motion stop (idx: {self._motion_event_id})")
             await self.send(
                 self.gen_response(
                     "EventSmartDetect" if object_type else "EventAnalytics",

--- a/unifi/cams/frigate.py
+++ b/unifi/cams/frigate.py
@@ -26,7 +26,8 @@ class FrigateCam(RTSPCam):
     def add_parser(cls, parser: argparse.ArgumentParser) -> None:
         super().add_parser(parser)
         parser.add_argument("--mqtt-host", required=True, help="MQTT server")
-        parser.add_argument("--mqtt-port", default=1883, type=int, help="MQTT server")
+        parser.add_argument("--mqtt-port", default=1883,
+                            type=int, help="MQTT server")
         parser.add_argument(
             "--mqtt-prefix", default="frigate", type=str, help="Topic prefix"
         )
@@ -115,7 +116,8 @@ class FrigateCam(RTSPCam):
                     ):
                         # Wait for the best snapshot to be ready before
                         # ending the motion event
-                        self.logger.info(f"Awaiting snapshot (id: {self.event_id})")
+                        self.logger.info(
+                            f"Awaiting snapshot (id: {self.event_id})")
                         await self.event_snapshot_ready.wait()
                         self.logger.info(
                             f"Ending {self.event_label} motion event"

--- a/unifi/cams/hikvision.py
+++ b/unifi/cams/hikvision.py
@@ -26,8 +26,10 @@ class HikvisionCam(UnifiCamBase):
     @classmethod
     def add_parser(cls, parser: argparse.ArgumentParser) -> None:
         super().add_parser(parser)
-        parser.add_argument("--username", "-u", required=True, help="Camera username")
-        parser.add_argument("--password", "-p", required=True, help="Camera password")
+        parser.add_argument("--username", "-u",
+                            required=True, help="Camera username")
+        parser.add_argument("--password", "-p",
+                            required=True, help="Camera password")
         parser.add_argument(
             "--channel", "-c", default=1, type=int, help="Camera channel index"
         )

--- a/unifi/cams/reolink.py
+++ b/unifi/cams/reolink.py
@@ -53,7 +53,8 @@ class Reolink(UnifiCamBase):
     async def run(self) -> None:
         url = (
             f"http://{self.args.ip}"
-            f"/api.cgi?user={self.args.username}&password={self.args.password}"
+            f"/api.cgi?cmd=GetMdState&user={self.args.username}"
+            f"&password={self.args.password}"
         )
         encoded_url = URL(url, encoded=True)
 

--- a/unifi/cams/reolink.py
+++ b/unifi/cams/reolink.py
@@ -15,7 +15,8 @@ class Reolink(UnifiCamBase):
         super().__init__(args, logger)
         self.snapshot_dir: str = tempfile.mkdtemp()
         self.motion_in_progress: bool = False
-
+        self.substream = args.substream
+        
     @classmethod
     def add_parser(cls, parser: argparse.ArgumentParser) -> None:
         super().add_parser(parser)
@@ -34,9 +35,20 @@ class Reolink(UnifiCamBase):
         parser.add_argument(
             "--channel",
             "-c",
-            required=True,
-            help="Camera channel (0 for main 1 for sub)"
+            default=0,
+            help="Camera channel (not needed, leaving for possible future)"
         )
+
+        parser.add_argument(
+            "--substream",
+            "-s",
+            default='main',
+            type=str,
+            choices=['main', 'sub'],
+            required=True,
+            help="Camera rtsp url substream index main, or sub"
+        )
+
 
     async def get_snapshot(self) -> Path:
         img_file = Path(self.snapshot_dir, "screen.jpg")
@@ -105,5 +117,5 @@ class Reolink(UnifiCamBase):
     def get_stream_source(self, stream_index: str) -> str:
         return (
             f"rtsp://{self.args.username}:{self.args.password}@{self.args.ip}:554"
-            f"//h264Preview_{int(self.args.channel) + 1:02}_main"
+            f"//h264Preview_{int(self.args.channel) + 1:02}_{self.args.substream}"
         )

--- a/unifi/cams/reolink.py
+++ b/unifi/cams/reolink.py
@@ -1,0 +1,92 @@
+import argparse
+import json
+import logging
+import tempfile
+from pathlib import Path
+
+import aiohttp
+from yarl import URL
+
+from unifi.cams.base import UnifiCamBase
+
+
+class Reolink(UnifiCamBase):
+    def __init__(self, args: argparse.Namespace, logger: logging.Logger) -> None:
+        super().__init__(args, logger)
+        self.snapshot_dir: str = tempfile.mkdtemp()
+        self.motion_in_progress: bool = False
+
+    @classmethod
+    def add_parser(cls, parser: argparse.ArgumentParser) -> None:
+        super().add_parser(parser)
+        parser.add_argument("--username", "-u", required=True, help="Camera username")
+        parser.add_argument("--password", "-p", required=True, help="Camera password")
+        parser.add_argument("--channel", "-c", required=True, help="Camera channel (0 for main 1 for sub)")
+
+    async def get_snapshot(self) -> Path:
+        img_file = Path(self.snapshot_dir, "screen.jpg")
+        url = (
+            f"http://{self.args.ip}"
+            f"/cgi-bin/api.cgi?cmd=Snap&channel={self.args.channel}"
+            f"&rs=6PHVjvf0UntSLbyT&user={self.args.username}&password={self.args.password}"
+        )
+        self.logger.info(f"Grabbing snapshot: {url}")
+        await self.fetch_to_file(url, img_file)
+        return img_file
+        
+    async def run(self) -> None:
+        url = (
+            f"http://{self.args.ip}"
+            f"/api.cgi?user={self.args.username}&password={self.args.password}"
+        )
+        encoded_url = URL(url, encoded=True)
+
+        body = (
+            f'[{{ "cmd":"GetMdState", "param":{{ "channel":{self.args.channel} }} }}]'
+        )
+        while True:
+            self.logger.info(f"Connecting to motion events API: {url}")
+            try:
+                async with aiohttp.ClientSession(
+                    timeout=aiohttp.ClientTimeout(None)
+                ) as session:
+                    while True:
+                        async with session.post(encoded_url, data=body) as resp:
+                            data = await resp.read()
+
+                            try:
+                                json_body = json.loads(data)
+                                if "value" in json_body[0]:
+                                    if json_body[0]["value"]["state"] == 1:
+                                        if not self.motion_in_progress:
+                                            self.motion_in_progress = True
+                                            self.logger.info("Trigger motion start")
+                                            await self.trigger_motion_start()
+                                    elif json_body[0]["value"]["state"] == 0:
+                                        if self.motion_in_progress:
+                                            self.motion_in_progress = False
+                                            self.logger.info("Trigger motion end")
+                                            await self.trigger_motion_stop()
+                                else:
+                                    self.logger.error(
+                                        "Motion API request responded with "
+                                        "unexpected JSON, retrying. "
+                                        f"JSON: {data}"
+                                    )
+
+                            except json.JSONDecodeError as err:
+                                self.logger.error(
+                                    "Motion API request returned invalid "
+                                    "JSON, retrying. "
+                                    f"Error: {err}, "
+                                    f"Response: {data}"
+                                )
+
+            except aiohttp.ClientError as err:
+                self.logger.error(f"Motion API request failed, retrying. Error: {err}")
+
+    def get_stream_source(self, stream_index: str) -> str:
+        return (
+            f"rtsp://{self.args.username}:{self.args.password}@{self.args.ip}:554"
+            f"//h264Preview_{int(self.args.channel) + 1:02}_main"
+        )

--- a/unifi/cams/reolink.py
+++ b/unifi/cams/reolink.py
@@ -19,21 +19,37 @@ class Reolink(UnifiCamBase):
     @classmethod
     def add_parser(cls, parser: argparse.ArgumentParser) -> None:
         super().add_parser(parser)
-        parser.add_argument("--username", "-u", required=True, help="Camera username")
-        parser.add_argument("--password", "-p", required=True, help="Camera password")
-        parser.add_argument("--channel", "-c", required=True, help="Camera channel (0 for main 1 for sub)")
+        parser.add_argument(
+            "--username",
+            "-u",
+            required=True,
+            help="Camera username"
+        )
+        parser.add_argument(
+            "--password",
+            "-p",
+            required=True,
+            help="Camera password"
+        )
+        parser.add_argument(
+            "--channel",
+            "-c",
+            required=True,
+            help="Camera channel (0 for main 1 for sub)"
+        )
 
     async def get_snapshot(self) -> Path:
         img_file = Path(self.snapshot_dir, "screen.jpg")
         url = (
             f"http://{self.args.ip}"
             f"/cgi-bin/api.cgi?cmd=Snap&channel={self.args.channel}"
-            f"&rs=6PHVjvf0UntSLbyT&user={self.args.username}&password={self.args.password}"
+            f"&rs=6PHVjvf0UntSLbyT&user={self.args.username}"
+            f"&password={self.args.password}"
         )
         self.logger.info(f"Grabbing snapshot: {url}")
         await self.fetch_to_file(url, img_file)
         return img_file
-        
+
     async def run(self) -> None:
         url = (
             f"http://{self.args.ip}"

--- a/unifi/cams/reolink.py
+++ b/unifi/cams/reolink.py
@@ -11,12 +11,13 @@ from unifi.cams.base import UnifiCamBase
 
 
 class Reolink(UnifiCamBase):
-    def __init__(self, args: argparse.Namespace, logger: logging.Logger) -> None:
+    def __init__(self, args: argparse.Namespace,
+                 logger: logging.Logger) -> None:
         super().__init__(args, logger)
         self.snapshot_dir: str = tempfile.mkdtemp()
         self.motion_in_progress: bool = False
         self.substream = args.substream
-        
+
     @classmethod
     def add_parser(cls, parser: argparse.ArgumentParser) -> None:
         super().add_parser(parser)
@@ -48,7 +49,6 @@ class Reolink(UnifiCamBase):
             required=True,
             help="Camera rtsp url substream index main, or sub"
         )
-
 
     async def get_snapshot(self) -> Path:
         img_file = Path(self.snapshot_dir, "screen.jpg")
@@ -89,12 +89,14 @@ class Reolink(UnifiCamBase):
                                     if json_body[0]["value"]["state"] == 1:
                                         if not self.motion_in_progress:
                                             self.motion_in_progress = True
-                                            self.logger.info("Trigger motion start")
+                                            self.logger.info(
+                                                "Trigger motion start")
                                             await self.trigger_motion_start()
                                     elif json_body[0]["value"]["state"] == 0:
                                         if self.motion_in_progress:
                                             self.motion_in_progress = False
-                                            self.logger.info("Trigger motion end")
+                                            self.logger.info(
+                                                "Trigger motion end")
                                             await self.trigger_motion_stop()
                                 else:
                                     self.logger.error(
@@ -112,10 +114,10 @@ class Reolink(UnifiCamBase):
                                 )
 
             except aiohttp.ClientError as err:
-                self.logger.error(f"Motion API request failed, retrying. Error: {err}")
+                self.logger.error(
+                    f"Motion API request failed, retrying. Error: {err}")
 
     def get_stream_source(self, stream_index: str) -> str:
         return (
             f"rtsp://{self.args.username}:{self.args.password}@{self.args.ip}:554"
-            f"//h264Preview_{int(self.args.channel) + 1:02}_{self.args.substream}"
-        )
+            f"//h264Preview_{int(self.args.channel) + 1:02}_{self.args.substream}")

--- a/unifi/cams/reolink_nvr.py
+++ b/unifi/cams/reolink_nvr.py
@@ -19,9 +19,12 @@ class ReolinkNVRCam(UnifiCamBase):
     @classmethod
     def add_parser(cls, parser: argparse.ArgumentParser) -> None:
         super().add_parser(parser)
-        parser.add_argument("--username", "-u", required=True, help="NVR username")
-        parser.add_argument("--password", "-p", required=True, help="NVR password")
-        parser.add_argument("--channel", "-c", required=True, help="NVR camera channel")
+        parser.add_argument("--username", "-u",
+                            required=True, help="NVR username")
+        parser.add_argument("--password", "-p",
+                            required=True, help="NVR password")
+        parser.add_argument("--channel", "-c", required=True,
+                            help="NVR camera channel")
 
     async def get_snapshot(self) -> Path:
         img_file = Path(self.snapshot_dir, "screen.jpg")
@@ -59,12 +62,14 @@ class ReolinkNVRCam(UnifiCamBase):
                                     if json_body[0]["value"]["state"] == 1:
                                         if not self.motion_in_progress:
                                             self.motion_in_progress = True
-                                            self.logger.info("Trigger motion start")
+                                            self.logger.info(
+                                                "Trigger motion start")
                                             await self.trigger_motion_start()
                                     elif json_body[0]["value"]["state"] == 0:
                                         if self.motion_in_progress:
                                             self.motion_in_progress = False
-                                            self.logger.info("Trigger motion end")
+                                            self.logger.info(
+                                                "Trigger motion end")
                                             await self.trigger_motion_stop()
                                 else:
                                     self.logger.error(
@@ -82,7 +87,8 @@ class ReolinkNVRCam(UnifiCamBase):
                                 )
 
             except aiohttp.ClientError as err:
-                self.logger.error(f"Motion API request failed, retrying. Error: {err}")
+                self.logger.error(
+                    f"Motion API request failed, retrying. Error: {err}")
 
     def get_stream_source(self, stream_index: str) -> str:
         return (

--- a/unifi/core.py
+++ b/unifi/core.py
@@ -24,7 +24,8 @@ class Core(object):
         self.ssl_context.load_cert_chain(args.cert, args.cert)
 
     async def run(self) -> None:
-        uri = "wss://{}:7442/camera/1.0/ws?token={}".format(self.host, self.token)
+        uri = "wss://{}:7442/camera/1.0/ws?token={}".format(
+            self.host, self.token)
         headers = {"camera-mac": self.mac}
         has_connected = False
 

--- a/unifi/main.py
+++ b/unifi/main.py
@@ -24,7 +24,8 @@ CAMS = {
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--version", action="version", version=__version__)
-    parser.add_argument("--host", "-H", required=True, help="NVR ip address and port")
+    parser.add_argument("--host", "-H", required=True,
+                        help="NVR ip address and port")
     parser.add_argument(
         "--cert",
         "-c",
@@ -33,7 +34,11 @@ def parse_args():
         help="Client certificate path",
     )
     parser.add_argument("--token", "-t", required=True, help="Adoption token")
-    parser.add_argument("--mac", "-m", default="AABBCCDDEEFF", help="MAC address")
+    parser.add_argument(
+        "--mac",
+        "-m",
+        default="AABBCCDDEEFF",
+        help="MAC address")
     parser.add_argument(
         "--ip",
         "-i",

--- a/unifi/main.py
+++ b/unifi/main.py
@@ -6,13 +6,13 @@ from shutil import which
 
 import coloredlogs
 
-from unifi.cams import (  DahuaCam,
-    FrigateCam,
-    HikvisionCam,
-    Reolink,
-    ReolinkNVRCam,
-    RTSPCam,
-)
+from unifi.cams import (DahuaCam,
+                        FrigateCam,
+                        HikvisionCam,
+                        Reolink,
+                        ReolinkNVRCam,
+                        RTSPCam,
+                        )
 from unifi.core import Core
 from unifi.version import __version__
 

--- a/unifi/main.py
+++ b/unifi/main.py
@@ -6,13 +6,14 @@ from shutil import which
 
 import coloredlogs
 
-from unifi.cams import (DahuaCam,
-                        FrigateCam,
-                        HikvisionCam,
-                        Reolink,
-                        ReolinkNVRCam,
-                        RTSPCam,
-                        )
+from unifi.cams import (
+    DahuaCam,
+    FrigateCam,
+    HikvisionCam,
+    Reolink,
+    ReolinkNVRCam,
+    RTSPCam,
+)
 from unifi.core import Core
 from unifi.version import __version__
 

--- a/unifi/main.py
+++ b/unifi/main.py
@@ -6,7 +6,7 @@ from shutil import which
 
 import coloredlogs
 
-from unifi.cams import DahuaCam, FrigateCam, HikvisionCam, Reolink, ReolinkNVRCam, RTSPCam
+from unifi.cams import DahuaCam, FrigateCam, HikvisionCam, Reolink, ReolinkNVRCam, RTSPCam # noqa
 from unifi.core import Core
 from unifi.version import __version__
 

--- a/unifi/main.py
+++ b/unifi/main.py
@@ -6,7 +6,13 @@ from shutil import which
 
 import coloredlogs
 
-from unifi.cams import DahuaCam, FrigateCam, HikvisionCam, Reolink, ReolinkNVRCam, RTSPCam # noqa
+from unifi.cams import (  DahuaCam,
+    FrigateCam,
+    HikvisionCam,
+    Reolink,
+    ReolinkNVRCam,
+    RTSPCam,
+)
 from unifi.core import Core
 from unifi.version import __version__
 

--- a/unifi/main.py
+++ b/unifi/main.py
@@ -6,7 +6,7 @@ from shutil import which
 
 import coloredlogs
 
-from unifi.cams import DahuaCam, FrigateCam, HikvisionCam, ReolinkNVRCam, RTSPCam
+from unifi.cams import DahuaCam, FrigateCam, HikvisionCam, Reolink, ReolinkNVRCam, RTSPCam
 from unifi.core import Core
 from unifi.version import __version__
 
@@ -15,6 +15,7 @@ CAMS = {
     "hikvision": HikvisionCam,
     "lorex": DahuaCam,
     "dahua": DahuaCam,
+    "reolink": Reolink,
     "reolink_nvr": ReolinkNVRCam,
     "rtsp": RTSPCam,
 }


### PR DESCRIPTION
Work in progress getting Standalone Reolink cams to work more in line with how t he ReolinkNVR parts work.  

What's working:

* Motion detection
* Spawning a stream on the main or substream and proxying it to Unifi Protect. using ```-s main, or -s sub``` argument note,  is maximum 15fps so use ```tick_rate-30000/1001```
* Using the proper API url for snapshot grabbing

What's not working:
* Spawning Video streams according to their main/sub ie: spawning the main stream for live view and recording and the sub stream for preview to save resources. 
*  Any version of ffmpeg over v4.1.8 as it seems to not pars the h264_metatdata flags properly and crashes the streams causing a respawn loop.

Examples on how to use:
* Standalone cameras using proper Snapshot URL and Motion-Det API url using Camera Substream (main or sub) *work in progress*

Main camera stream example
```
unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> reolink -u <username> -p <password> -s main --ffmpeg-args='-c:v copy -bsf:v "h264_metadata=tick_rate=60000/1001:fixed_frame_rate_flag=1" -ar 32000 -ac 2 -codec:a aac -b:a 32k'
```
Sub camera stream example
```
unifi-cam-proxy -H <NVR IP> -i <camera IP> -c client.pem -t <Adoption token> reolink -u <username> -p <password> -s sub --ffmpeg-args='-c:v copy -bsf:v "h264_metadata=tick_rate=30000/1001:fixed_frame_rate_flag=1" -ar 32000 -ac 2 -codec:a aac -b:a 32k''
```
* (Note: Camera/channel arguments are either -s main, or -s sub. The substream is limited to a maximum 15fps so note the tick_rate in the example)


* **Possibly a limitation of my VM I'm testing I cannot get smooth Live view on mobile/web if the main streams bitrate is over 
1024**

The Reolink part of this project seems to not work well any more many of us seem to fail to get it to work.  I'm not a pro but this is my small contribution, and I'm learning along the way.