### PR TITLE
Better resiliency

### DIFF
--- a/unifi/core.py
+++ b/unifi/core.py
@@ -57,10 +57,12 @@ class Core(object):
                 elif e.status_code == 429:
                     return True
                 raise
+            except asyncio.exceptions.TimeoutError:
+                self.logger.info(f"Connection to {self.host} timed out.")
+                return True
             except ConnectionRefusedError:
-                if has_connected:
-                    return True
-                raise
+                self.logger.info(f"Connection to {self.host} refused.")
+                return True
 
             try:
                 await asyncio.gather(self.cam._run(ws), self.cam.run())


### PR DESCRIPTION
A few changes for better resiliency that I had in my own fork prior to your work on the Amcrest stuff (thanks again for that - never thought to look for a dedicated python package):
- Don't buffer ffmpeg stderr. Instead, set ffmpeg output level to err and let stderr pass through. Fixes #148.
- Make resilient against shutdowns/restarts of Unifi Protect. During the restart of a Cloud Key Gen2+, both connection timeouts and connection refused will occur. Keep retrying when either of these happen.

I removed the `has_connected` logic for ConnectionRefused because one can imagine a scenario after a power outage where the device running unifi-cam-proxy recovers faster than the CKG2+ (or whatever Protect is running on). The introduction of a log message will make it clear to the user what is happening if they misconfigured the IP address that Protect is running at.

If you end up wanting to go a different route on #148, feel free to close this PR and just copy the changes for `core.py`.