### PR TITLE
Add vscode devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+ARG VARIANT="3.8"
+FROM mcr.microsoft.com/vscode/devcontainers/python:dev-${VARIANT}-buster
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y ffmpeg netcat-openbsd
+
+COPY . .
+RUN pip install .

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,50 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.217.4/containers/docker-existing-dockerfile
+{
+	"name": "unifi-cam-proxy",
+
+	// Sets the run context to one level up instead of the .devcontainer folder.
+	"context": "..",
+
+	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+	"dockerFile": "Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+    "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash",
+        "python.pythonPath": "/usr/local/bin/python",
+        "python.linting.enabled": true,
+        "python.linting.pylintEnabled": false,
+        "python.linting.flake8Enabled": true,
+        "python.formatting.provider": "black",
+        "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+        "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+        "python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+        "python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+        "python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+        "python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+        "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+        "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+        "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
+    },
+	
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+        "ms-python.python",
+    ]
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+
+	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ run/
 MANIFEST
 MANIFEST.in
 .pyre/
+.vscode/settings.json
+.vscode/launch.json


### PR DESCRIPTION
Adding support for [vs code devcontainers](https://code.visualstudio.com/docs/remote/containers).

For debugging of python:

![image](https://user-images.githubusercontent.com/1678318/155012598-71287e7e-bda2-42ea-80a6-4dee3fea5e1e.png)

Just add your own launch.json file to pass in debug arguments eg:

```json
{
    "version": "0.2.0",
    "configurations": [

        {
            "name": "unifi-cam-proxy",
            "type": "python",
            "request": "launch",
            "module": "main",
            "cwd": "${workspaceFolder}/unifi",
            "pythonArgs": [
                "-X dev",
            ],
            "args": [
                "--host={your-host-ip}",
                "--token={your-token}",
                "--mac={your-mac}",
                "--cert=../client.pem",
                "rtsp",
                "-s=rtsp://{your-rtsp}",
            ],
            "console": "integratedTerminal",
            "subProcess": true,
            "env": {
                "PYTHONASYNCIODEBUG": "1"
            }            
        }
    ]
}
```