### PR TITLE
bump alpine to 3.17 and python version to 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.8-alpine3.10
+FROM python:3.9-alpine3.17
 WORKDIR /app
 
 RUN apk add --update gcc libc-dev linux-headers libusb-dev
-RUN apk add --update ffmpeg=4.1.6-r0 netcat-openbsd git
+RUN apk add --update ffmpeg netcat-openbsd git
 
 COPY . .
 RUN pip install .


### PR DESCRIPTION
Updated dockerfile to bump alpine to pull latest ffmpeg and python version to 3.9 to match pyunifiprotect required version.
Haven't been able to get streaming working yet on my camera (HD IPC), but no errors are reported in the console this time.

