### PR TITLE
🛠️ Fixed deprecated `set-output` commands

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -28,9 +28,11 @@ jobs:
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             TAGS="$TAGS,${DOCKER_IMAGE}:latest"
           fi
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+          echo version=${VERSION} >> $GITHUB_STATE
+          echo tags=${TAGS} >> $GITHUB_STATE
+          echo created=$(date -u +'%Y-%m-%dT%H:%M:%SZ') >> $GITHUB_STATE
+
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -42,7 +42,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2 
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,10 @@ amcrest
 asyncio-mqtt
 backoff
 coloredlogs
+flvlib3@https://github.com/zkonge/flvlib3/archive/master.zip
 hikvisionapi>=0.3.2
-https://github.com/zkonge/flvlib3/archive/master.zip
 packaging
 pyunifiprotect
 reolinkapi
 websockets>=9.0.1
 xmltodict
-


### PR DESCRIPTION
- Fixed deprecated `set-output` commands as described [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).
- Fixed a regression in `requirements.txt` not allowing the `flvlib3` to be properly installed.
- Bumped `docker/login-action` to `v2`.

*Replaces: #290, #295*