### PR TITLE
Tapo Camera support with PTZ

### DIFF
--- a/docs/docs/configuration/tapo.md
+++ b/docs/docs/configuration/tapo.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 # Tapo
 Unifi-cam-proxy has basic support for Tapo/TPlink cameras, like the C100 or C200 with PTZ. 
 
-To controll the PTZ functionality, you have to use the camera image settings in unifi. Adjusting the contrast to anything less than 20 pans the camera a bit to the left, anything over 80 to the right. The brightness setting controlls the tilt.
+To control the PTZ functionality, you have to use the camera image settings in unifi. Adjusting the contrast to anything less than 20 pans the camera a bit to the left, anything over 80 to the right. The brightness setting controls the tilt.
 
 Make sure to reset the brightness/contrast setting back to somewhere around 50 after adjusting the cameras position, to avoid adjusting the position by accident.
 

--- a/docs/docs/configuration/tapo.md
+++ b/docs/docs/configuration/tapo.md
@@ -1,0 +1,25 @@
+---
+sidebar_position: 1
+---
+
+# Tapo
+Unifi-cam-proxy has basic support for Tapo/TPlink cameras, like the C100 or C200 with PTZ. 
+
+To controll the PTZ functionality, you have to use the camera image settings in unifi. Adjusting the contrast to anything less than 20 pans the camera a bit to the left, anything over 80 to the right. The brightness setting controlls the tilt.
+
+Make sure to reset the brightness/contrast setting back to somewhere around 50 after adjusting the cameras position, to avoid adjusting the position by accident.
+
+## Standard
+```sh
+unifi-cam-proxy -H {NVR IP} -i {Camera IP} -c /client.pem -t {Adoption token} --mac 'AA:BB:CC:00:11:22'\
+  tapo \
+  --rtsp "rtsp://{camera_username}:{camera_password}@{camera_ip}:554"
+```
+
+## PTZ Support
+```sh
+unifi-cam-proxy -H {NVR IP} -i {Camera IP} -c /client.pem -t {Adoption token} --mac 'AA:BB:CC:00:11:22'\
+  tapo \
+  --rtsp "rtsp://{camera_username}:{camera_password}@{camera_ip}:554"\
+  --password "{TP Link account Password}"
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pyunifiprotect
 reolinkapi
 websockets>=9.0.1
 xmltodict
+pytapo

--- a/unifi/cams/__init__.py
+++ b/unifi/cams/__init__.py
@@ -4,12 +4,14 @@ from unifi.cams.hikvision import HikvisionCam
 from unifi.cams.reolink import Reolink
 from unifi.cams.reolink_nvr import ReolinkNVRCam
 from unifi.cams.rtsp import RTSPCam
+from unifi.cams.tapo import TapoCam
 
 __all__ = [
     "FrigateCam",
     "HikvisionCam",
     "DahuaCam",
     "RTSPCam",
+    "TapoCam",
     "Reolink",
     "ReolinkNVRCam",
 ]

--- a/unifi/cams/tapo.py
+++ b/unifi/cams/tapo.py
@@ -1,0 +1,155 @@
+import argparse
+import logging
+import subprocess
+import tempfile
+from pathlib import Path
+
+from aiohttp import web
+
+from unifi.cams.base import UnifiCamBase
+
+from pytapo import Tapo
+
+
+class TapoCam(UnifiCamBase):
+    def __init__(self, args: argparse.Namespace, logger: logging.Logger) -> None:
+        super().__init__(args, logger)
+        self.args = args
+        self.event_id = 0
+        self.snapshot_dir = tempfile.mkdtemp()
+        self.snapshot_stream = None
+        self.runner = None
+        self.stream_source = dict()
+        self.stream_source["video1"] = self.args.rtsp + "/stream1"
+        self.stream_source["video2"] = self.args.rtsp + "/stream1"
+        self.stream_source["video3"] = self.args.rtsp + "/stream2"
+        self.ptz_enabled = False
+        self.cam = None
+
+        try:
+            self.cam = Tapo(self.args.ip, self.args.username, self.args.password)
+            self.cam.getMotorCapability()
+            self.ptz_enabled = True
+
+        except AttributeError:
+            self.logger.info("PTZ Not enabled because of insufficient configuration")
+
+        except Exception:
+            self.logger.info("PTZ Not enabled, not supportet for this camera")
+
+        if not self.args.snapshot_url:
+            self.start_snapshot_stream()
+
+    @classmethod
+    def add_parser(cls, parser: argparse.ArgumentParser) -> None:
+        super().add_parser(parser)
+        parser.add_argument(
+            "--username",
+            "-u",
+            default="admin",
+            help="Username (default:admin)"
+        )
+        parser.add_argument(
+            "--password",
+            "-p",
+            help="Your TPlink app password"
+        )
+        parser.add_argument(
+            "--rtsp",
+            required=True,
+            help="Your RTSP base URL (rtsp://camera_username:camera_password@192.168.172.180:554)"
+        )
+        parser.add_argument(
+            "--http-api",
+            default=0,
+            type=int,
+            help="Specify a port number to enable the HTTP API (default: disabled)",
+        )
+        parser.add_argument(
+            "--snapshot-url",
+            "-i",
+            default=None,
+            type=str,
+            required=False,
+            help="HTTP endpoint to fetch snapshot image from",
+        )
+
+    def start_snapshot_stream(self) -> None:
+        if not self.snapshot_stream or self.snapshot_stream.poll() is not None:
+            cmd = (
+                f"ffmpeg -nostdin -y -re -rtsp_transport {self.args.rtsp_transport} "
+                f'-i "{self.stream_source["video3"]}" '
+                "-r 1 "
+                f"-update 1 {self.snapshot_dir}/screen.jpg"
+            )
+            self.logger.info(f"Spawning stream for snapshots: {cmd}")
+            self.snapshot_stream = subprocess.Popen(
+                cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, shell=True
+            )
+
+    async def get_snapshot(self) -> Path:
+        img_file = Path(self.snapshot_dir, "screen.jpg")
+        if self.args.snapshot_url:
+            await self.fetch_to_file(self.args.snapshot_url, img_file)
+        else:
+            self.start_snapshot_stream()
+        return img_file
+
+    #this gets called when settings are updated on the unifi ui
+    async def change_video_settings(self, options) -> None:
+        if self.ptz_enabled:
+            self.cam = Tapo(self.args.ip, self.args.username, self.args.password)
+            #move down
+            if int(options["brightness"]) < 20:
+                self.logger.info("Moving down")
+                self.cam.moveMotor(0, -10)
+            #move up
+            if int(options["brightness"]) > 80:
+                self.logger.info("Moving up")
+                self.cam.moveMotor(0, 10)
+            #move left
+            if int(options["contrast"]) > 80:
+                self.logger.info("Moving right")
+                self.cam.moveMotor(10, 0)
+            #move right
+            if int(options["contrast"]) < 20:
+                self.logger.info("Moving left")
+                self.cam.moveMotor(-10, 0)
+
+
+    async def run(self) -> None:
+        if self.ptz_enabled:
+            self.logger.debug("PTZ Enabled")
+        if self.args.http_api:
+            self.logger.info(f"Enabling HTTP API on port {self.args.http_api}")
+
+            app = web.Application()
+
+            async def start_motion(request):
+                self.logger.debug("Starting motion")
+                await self.trigger_motion_start()
+                return web.Response(text="ok")
+
+            async def stop_motion(request):
+                self.logger.debug("Starting motion")
+                await self.trigger_motion_stop()
+                return web.Response(text="ok")
+
+            app.add_routes([web.get("/start_motion", start_motion)])
+            app.add_routes([web.get("/stop_motion", stop_motion)])
+
+            self.runner = web.AppRunner(app)
+            await self.runner.setup()
+            site = web.TCPSite(self.runner, port=self.args.http_api)
+            await site.start()
+
+    async def close(self) -> None:
+        await super().close()
+        if self.runner:
+            await self.runner.cleanup()
+
+        if self.snapshot_stream:
+            self.snapshot_stream.kill()
+
+    async def get_stream_source(self, stream_index: str) -> str:
+        return self.stream_source[stream_index]

--- a/unifi/main.py
+++ b/unifi/main.py
@@ -14,6 +14,7 @@ from unifi.cams import (
     Reolink,
     ReolinkNVRCam,
     RTSPCam,
+    TapoCam,
 )
 from unifi.core import Core
 from unifi.version import __version__
@@ -27,6 +28,7 @@ CAMS = {
     "reolink": Reolink,
     "reolink_nvr": ReolinkNVRCam,
     "rtsp": RTSPCam,
+    "tapo": TapoCam,
 }
 
 
@@ -51,7 +53,7 @@ def parse_args():
         "--ip",
         "-i",
         default="192.168.1.10",
-        help="IP address of camera (only used to display in UI)",
+        help="IP address of camera (only used to display in UI and to connect Tapo/hikvision Cameras)",
     )
     parser.add_argument(
         "--name",


### PR DESCRIPTION
Some basic support for Tapo Cameras.

- Setup is improved. I found this https://github.com/keshavdv/unifi-cam-proxy/issues/193#issuecomment-1163813600 to be a little complicated.
- implementation is based on the rtsp.py I am not sure if I have removed all redundant functions however.
- Pan and Tilt setup is tested on C200. The implementation is a little bit hacky. Unfortunately the C200 does not support absolute positioning, so I am using brightness/contrast contol like the Hikvision cameras. Whenever the setting updates, it just moves the camera by 10 degrees, instead of to an absolute position. I would love to improve on this with Unifis native PTZ camera and controls, but I have not seen any of that data in the current version of unifi-cam-proxy.
Better than nothing though :D
- Normal setup is tested on C110