### PR TITLE
Improve RTSP metadata handling

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,43 @@
+import sys
+import types
+
+
+def install_stub(name: str, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+install_stub("amcrest", AmcrestCamera=object)
+install_stub("amcrest.exceptions", CommError=Exception)
+install_stub("hikvisionapi", AsyncClient=object)
+install_stub("reolinkapi", Camera=object)
+install_stub("pytapo", Tapo=object)
+websockets_client = install_stub("websockets.client", WebSocketClientProtocol=object)
+websockets_exceptions = install_stub(
+    "websockets.exceptions", ConnectionClosedError=Exception
+)
+websockets = install_stub(
+    "websockets", client=websockets_client, exceptions=websockets_exceptions
+)
+websockets.client = websockets_client
+websockets.exceptions = websockets_exceptions
+
+aiomqtt = install_stub("aiomqtt", Client=object, Message=object)
+aiomqtt_exceptions = install_stub("aiomqtt.exceptions", MqttError=Exception)
+aiomqtt.exceptions = aiomqtt_exceptions
+asyncio_mqtt = install_stub("asyncio_mqtt", Client=object)
+asyncio_mqtt_error = install_stub("asyncio_mqtt.error", MqttError=Exception)
+asyncio_mqtt.error = asyncio_mqtt_error
+
+
+def _backoff_decorator(*_args, **_kwargs):
+    def decorator(fn):
+        return fn
+
+    return decorator
+
+
+install_stub("backoff", on_predicate=_backoff_decorator, expo=lambda *_args, **_kwargs: None)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,82 @@
+import argparse
+import asyncio
+import logging
+
+from unifi.cams.base import UnifiCamBase
+
+
+class DummySSLContext:
+    def __init__(self):
+        self.check_hostname = True
+        self.verify_mode = None
+
+    def load_cert_chain(self, *_args, **_kwargs):
+        return None
+
+
+class DummyCam(UnifiCamBase):
+    async def get_snapshot(self):
+        raise NotImplementedError
+
+    async def get_stream_source(self, _stream_index: str) -> str:
+        return "rtsp://example.invalid/test"
+
+
+def build_args():
+    return argparse.Namespace(
+        cert="/tmp/client.pem",
+        ffmpeg_args="-c copy",
+        ffmpeg_base_args=None,
+        rtsp_transport="tcp",
+        timestamp_modifier=90,
+        loglevel="error",
+        format="flv",
+        token="token",
+        mac="AA:BB:CC:DD:EE:FF",
+        host="protect.example",
+        fw_version="test",
+        ip="192.0.2.10",
+        model="UVC G3",
+        name="camera",
+    )
+
+
+def test_process_video_settings_preserves_channel_specific_rtsp_aliases(monkeypatch):
+    monkeypatch.setattr("ssl.create_default_context", lambda: DummySSLContext())
+
+    cam = DummyCam(build_args(), logging.getLogger("test"))
+    message = {
+        "messageId": 42,
+        "payload": {
+            "video": {
+                "video1": {"rtspAlias": "alias-high"},
+                "video2": {"rtspAlias": "alias-medium"},
+                "video3": {"rtspAlias": "alias-low"},
+            }
+        },
+    }
+
+    response = asyncio.run(cam.process_video_settings(message))
+    video = response["payload"]["video"]
+
+    assert video["video1"]["rtspAlias"] == "alias-high"
+    assert video["video2"]["rtspAlias"] == "alias-medium"
+    assert video["video3"]["rtspAlias"] == "alias-low"
+    assert video["video1"]["isRtspEnabled"] is True
+    assert video["video2"]["isRtspEnabled"] is True
+    assert video["video3"]["isRtspEnabled"] is True
+
+
+def test_process_video_settings_leaves_rtsp_disabled_without_alias(monkeypatch):
+    monkeypatch.setattr("ssl.create_default_context", lambda: DummySSLContext())
+
+    cam = DummyCam(build_args(), logging.getLogger("test"))
+    response = asyncio.run(cam.process_video_settings({"messageId": 1, "payload": None}))
+    video = response["payload"]["video"]
+
+    assert video["video1"]["rtspAlias"] is None
+    assert video["video2"]["rtspAlias"] is None
+    assert video["video3"]["rtspAlias"] is None
+    assert video["video1"]["isRtspEnabled"] is False
+    assert video["video2"]["isRtspEnabled"] is False
+    assert video["video3"]["isRtspEnabled"] is False

--- a/tests/test_rtsp.py
+++ b/tests/test_rtsp.py
@@ -1,0 +1,86 @@
+import argparse
+import json
+import logging
+import subprocess
+
+from unifi.cams.rtsp import RTSPCam
+
+
+class DummySSLContext:
+    def __init__(self):
+        self.check_hostname = True
+        self.verify_mode = None
+
+    def load_cert_chain(self, *_args, **_kwargs):
+        return None
+
+
+def build_args():
+    return argparse.Namespace(
+        cert="/tmp/client.pem",
+        ffmpeg_args="-c copy",
+        ffmpeg_base_args=None,
+        rtsp_transport="tcp",
+        timestamp_modifier=90,
+        loglevel="error",
+        format="flv",
+        token="token",
+        mac="AA:BB:CC:DD:EE:FF",
+        host="protect.example",
+        fw_version="test",
+        ip="192.0.2.10",
+        model="UVC G3",
+        name="camera",
+        source=[
+            "rtsp://example.invalid/high",
+            "rtsp://example.invalid/medium",
+            "rtsp://example.invalid/low",
+        ],
+        http_api=0,
+        snapshot_url="http://example.invalid/snapshot.jpg",
+    )
+
+
+def test_rtsp_cam_probes_dimensions_per_stream(monkeypatch):
+    monkeypatch.setattr("ssl.create_default_context", lambda: DummySSLContext())
+
+    calls = []
+
+    def fake_check_output(cmd):
+        source = cmd[-1]
+        calls.append(source)
+        dimensions = {
+            "rtsp://example.invalid/high": {"width": 1280, "height": 960},
+            "rtsp://example.invalid/medium": {"width": 640, "height": 480},
+            "rtsp://example.invalid/low": {"width": 352, "height": 240},
+        }[source]
+        return json.dumps({"streams": [dimensions]}).encode()
+
+    monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+
+    cam = RTSPCam(build_args(), logging.getLogger("test"))
+
+    assert cam.get_stream_dimensions("video1") == {"width": 1280, "height": 960}
+    assert cam.get_stream_dimensions("video2") == {"width": 640, "height": 480}
+    assert cam.get_stream_dimensions("video3") == {"width": 352, "height": 240}
+    assert cam.get_stream_dimensions("mjpg") == {"width": 1280, "height": 960}
+    assert calls == [
+        "rtsp://example.invalid/high",
+        "rtsp://example.invalid/medium",
+        "rtsp://example.invalid/low",
+    ]
+
+
+def test_rtsp_cam_dimension_probe_falls_back_to_defaults(monkeypatch):
+    monkeypatch.setattr("ssl.create_default_context", lambda: DummySSLContext())
+
+    def fake_check_output(_cmd):
+        raise subprocess.CalledProcessError(returncode=1, cmd="ffprobe")
+
+    monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+
+    cam = RTSPCam(build_args(), logging.getLogger("test"))
+
+    assert cam.get_stream_dimensions("video1") == {"width": 1920, "height": 1080}
+    assert cam.get_stream_dimensions("video2") == {"width": 1280, "height": 720}
+    assert cam.get_stream_dimensions("video3") == {"width": 640, "height": 360}

--- a/unifi/cams/base.py
+++ b/unifi/cams/base.py
@@ -41,6 +41,11 @@ class UnifiCamBase(metaclass=ABCMeta):
         self._motion_event_ts: Optional[float] = None
         self._motion_object_type: Optional[SmartDetectObjectType] = None
         self._ffmpeg_handles: dict[str, subprocess.Popen] = {}
+        self._rtsp_aliases: dict[str, Optional[str]] = {
+            "video1": None,
+            "video2": None,
+            "video3": None,
+        }
 
         # Set up ssl context for requests
         self._ssl_context = ssl.create_default_context()
@@ -103,11 +108,28 @@ class UnifiCamBase(metaclass=ABCMeta):
     def get_extra_ffmpeg_args(self, stream_index: str = "") -> str:
         return self.args.ffmpeg_args
 
+    def get_rtsp_alias(self, stream_index: str) -> Optional[str]:
+        return self._rtsp_aliases[stream_index]
+
+    def get_stream_dimensions(self, stream_index: str) -> dict[str, int]:
+        defaults = {
+            "mjpg": {"width": 1280, "height": 720},
+            "video1": {"width": 1920, "height": 1080},
+            "video2": {"width": 1280, "height": 720},
+            "video3": {"width": 640, "height": 360},
+        }
+        return defaults[stream_index]
+
     async def get_feature_flags(self) -> dict[str, Any]:
         return {
             "mic": True,
             "aec": [],
+            "audioCodecs": ["aac"],
+            "streamEncryptable": True,
+            "supportFullHdSnapshot": True,
+            "supportMinMotionAdaptiveBitrate": True,
             "videoMode": ["default"],
+            "videoCodecs": ["h264", "mjpg"],
             "motionDetect": ["enhanced"],
         }
 
@@ -243,12 +265,15 @@ class UnifiCamBase(metaclass=ABCMeta):
                     "idleTime": 191.96,
                     "ip": self.args.ip,
                     "mac": self.args.mac,
+                    "marketName": self.args.model,
                     "model": self.args.model,
                     "name": self.args.name,
+                    "platform": "s5l",
                     "protocolVersion": 67,
                     "rebootTimeoutSec": 30,
                     "semver": "v4.4.8",
                     "totalLoad": 0.5474,
+                    "type": self.args.model,
                     "upgradeTimeoutSec": 150,
                     "uptime": int(self.get_uptime()),
                     "features": await self.get_feature_flags(),
@@ -342,6 +367,10 @@ class UnifiCamBase(metaclass=ABCMeta):
         )
 
     async def process_video_settings(self, msg: AVClientRequest) -> AVClientResponse:
+        dimensions = {
+            stream_index: self.get_stream_dimensions(stream_index)
+            for stream_index in ["mjpg", "video1", "video2", "video3"]
+        }
         vid_dst = {
             "video1": ["file:///dev/null"],
             "video2": ["file:///dev/null"],
@@ -351,6 +380,8 @@ class UnifiCamBase(metaclass=ABCMeta):
         if msg["payload"] is not None and "video" in msg["payload"]:
             for k, v in msg["payload"]["video"].items():
                 if v:
+                    if "rtspAlias" in v:
+                        self._rtsp_aliases[k] = v["rtspAlias"]
                     if "avSerializer" in v:
                         vid_dst[k] = v["avSerializer"]["destinations"]
                         if "/dev/null" in vid_dst[k]:
@@ -412,7 +443,7 @@ class UnifiCamBase(metaclass=ABCMeta):
                         "description": "JPEG pictures",
                         "enabled": True,
                         "fps": 5,
-                        "height": 720,
+                        "height": dimensions["mjpg"]["height"],
                         "isCbr": False,
                         "maxFps": 5,
                         "minClientAdaptiveBitRate": 0,
@@ -426,7 +457,7 @@ class UnifiCamBase(metaclass=ABCMeta):
                         "type": "mjpg",
                         "validBitrateRangeMax": 6000000,
                         "validBitrateRangeMin": 32000,
-                        "width": 1280,
+                        "width": dimensions["mjpg"]["width"],
                     },
                     "video1": {
                         "M": 1,
@@ -451,14 +482,18 @@ class UnifiCamBase(metaclass=ABCMeta):
                         "enabled": True,
                         "fps": 15,
                         "gopModel": 0,
-                        "height": 1080,
+                        "height": dimensions["video1"]["height"],
                         "horizontalFlip": False,
                         "isCbr": False,
+                        "isInternalRtspEnabled": False,
+                        "isRtspEnabled": self._rtsp_aliases["video1"] is not None,
+                        "internalRtspAlias": None,
                         "maxFps": 30,
                         "minClientAdaptiveBitRate": 0,
                         "minMotionAdaptiveBitRate": 0,
                         "nMultiplier": 6,
                         "name": "video1",
+                        "rtspAlias": self._rtsp_aliases["video1"],
                         "sourceId": 0,
                         "streamId": 1,
                         "streamOrdinal": 0,
@@ -485,7 +520,7 @@ class UnifiCamBase(metaclass=ABCMeta):
                             30,
                         ],
                         "verticalFlip": False,
-                        "width": 1920,
+                        "width": dimensions["video1"]["width"],
                     },
                     "video2": {
                         "M": 1,
@@ -511,14 +546,18 @@ class UnifiCamBase(metaclass=ABCMeta):
                         "enabled": True,
                         "fps": 15,
                         "gopModel": 0,
-                        "height": 720,
+                        "height": dimensions["video2"]["height"],
                         "horizontalFlip": False,
                         "isCbr": False,
+                        "isInternalRtspEnabled": False,
+                        "isRtspEnabled": self._rtsp_aliases["video2"] is not None,
+                        "internalRtspAlias": None,
                         "maxFps": 30,
                         "minClientAdaptiveBitRate": 0,
                         "minMotionAdaptiveBitRate": 0,
                         "nMultiplier": 6,
                         "name": "video2",
+                        "rtspAlias": self._rtsp_aliases["video2"],
                         "sourceId": 1,
                         "streamId": 2,
                         "streamOrdinal": 1,
@@ -545,7 +584,7 @@ class UnifiCamBase(metaclass=ABCMeta):
                             30,
                         ],
                         "verticalFlip": False,
-                        "width": 1280,
+                        "width": dimensions["video2"]["width"],
                     },
                     "video3": {
                         "M": 1,
@@ -571,14 +610,18 @@ class UnifiCamBase(metaclass=ABCMeta):
                         "enabled": True,
                         "fps": 15,
                         "gopModel": 0,
-                        "height": 360,
+                        "height": dimensions["video3"]["height"],
                         "horizontalFlip": False,
                         "isCbr": False,
+                        "isInternalRtspEnabled": False,
+                        "isRtspEnabled": self._rtsp_aliases["video3"] is not None,
+                        "internalRtspAlias": None,
                         "maxFps": 30,
                         "minClientAdaptiveBitRate": 0,
                         "minMotionAdaptiveBitRate": 0,
                         "nMultiplier": 6,
                         "name": "video3",
+                        "rtspAlias": self._rtsp_aliases["video3"],
                         "sourceId": 2,
                         "streamId": 4,
                         "streamOrdinal": 2,
@@ -605,7 +648,7 @@ class UnifiCamBase(metaclass=ABCMeta):
                             30,
                         ],
                         "verticalFlip": False,
-                        "width": 640,
+                        "width": dimensions["video3"]["width"],
                     },
                     "vinFps": 30,
                 },

--- a/unifi/cams/rtsp.py
+++ b/unifi/cams/rtsp.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import logging
 import subprocess
 import tempfile
@@ -18,6 +19,7 @@ class RTSPCam(UnifiCamBase):
         self.snapshot_stream = None
         self.runner = None
         self.stream_source = dict()
+        self.stream_dimensions = dict()
         for i, stream_index in enumerate(["video1", "video2", "video3"]):
             if not i < len(self.args.source):
                 i = -1
@@ -105,3 +107,54 @@ class RTSPCam(UnifiCamBase):
 
     async def get_stream_source(self, stream_index: str) -> str:
         return self.stream_source[stream_index]
+
+    def get_stream_dimensions(self, stream_index: str) -> dict[str, int]:
+        if stream_index == "mjpg":
+            stream_index = "video1"
+
+        if stream_index not in self.stream_dimensions:
+            self.stream_dimensions[stream_index] = self.probe_stream_dimensions(
+                stream_index, self.stream_source[stream_index]
+            )
+
+        return self.stream_dimensions[stream_index]
+
+    def probe_stream_dimensions(
+        self, stream_index: str, source: str
+    ) -> dict[str, int]:
+        try:
+            output = subprocess.check_output(
+                [
+                    "ffprobe",
+                    "-v",
+                    "error",
+                    "-rtsp_transport",
+                    self.args.rtsp_transport,
+                    "-select_streams",
+                    "v:0",
+                    "-show_entries",
+                    "stream=width,height",
+                    "-of",
+                    "json",
+                    source,
+                ]
+            )
+            payload = json.loads(output)
+            stream = payload["streams"][0]
+            return {
+                "width": int(stream["width"]),
+                "height": int(stream["height"]),
+            }
+        except (
+            FileNotFoundError,
+            subprocess.CalledProcessError,
+            json.JSONDecodeError,
+            IndexError,
+            KeyError,
+            ValueError,
+        ):
+            self.logger.warning(
+                "Could not determine stream dimensions for %s, using defaults",
+                stream_index,
+            )
+            return super().get_stream_dimensions(stream_index)


### PR DESCRIPTION
## Summary

This updates the RTSP camera implementation so the metadata it advertises matches the actual configured RTSP sources.

## Changes

- preserve RTSP aliases per channel
- advertise RTSP enablement on a per-channel basis
- derive RTSP stream dimensions from the configured source URLs with `ffprobe`
- cache probed dimensions per stream
- fall back to the existing default dimensions if probing fails
- add pytest coverage for alias handling and dimension probing/fallback

## Why

Protect appears to use the metadata returned by `ChangeVideoSettings` for live-view behavior. When that metadata does not match the real stream, clients can behave incorrectly even if the stream itself is fine.

## Validation

- `pytest tests/test_base.py tests/test_rtsp.py`

Closes #412