### PR TITLE
Fix Protect 7.x video streaming via ms pullStream CLI

### DIFF
--- a/unifi/cams/base.py
+++ b/unifi/cams/base.py
@@ -1,4 +1,5 @@
 import argparse
+import asyncio
 import atexit
 import json
 import logging
@@ -41,6 +42,7 @@ class UnifiCamBase(metaclass=ABCMeta):
         self._motion_event_ts: Optional[float] = None
         self._motion_object_type: Optional[SmartDetectObjectType] = None
         self._ffmpeg_handles: dict[str, subprocess.Popen] = {}
+        self._stream_tasks: dict[str, any] = {}
 
         # Set up ssl context for requests
         self._ssl_context = ssl.create_default_context()
@@ -922,11 +924,59 @@ class UnifiCamBase(metaclass=ABCMeta):
     async def start_video_stream(
         self, stream_index: str, stream_name: str, destination: tuple[str, int]
     ):
+        """Start video via ms CLI pullStream command.
+
+        Protect 7.x uses a proprietary LiveFLV protocol that requires
+        ingest points created via the ms binary's CLI. Instead of trying
+        to push FLV data, we tell ms to pull the RTSP source directly
+        using the pullStream CLI command on port 1112.
+
+        Falls back to the legacy ffmpeg+clock_sync pipeline if the CLI
+        connection fails (e.g. no SSH tunnel to the NVR).
+        """
+        channel = {"video1": 0, "video2": 1, "video3": 2}.get(stream_index, 0)
+        mac_upper = self.args.mac.replace(":", "").upper()
+        local_name = f"{mac_upper}_{channel}"
+
+        if stream_index in self._stream_tasks:
+            return
+
+        source = await self.get_stream_source(stream_index)
+
+        # Try pullStream via ms CLI (Protect 7.x)
+        try:
+            import socket as _sock
+            cli = _sock.socket(_sock.AF_INET, _sock.SOCK_STREAM)
+            cli.settimeout(5)
+            cli.connect((destination[0], 1112))
+            cmd = (
+                f"pullStream uri={source} localStreamName={local_name}"
+                f" forceTcp=1 keepAlive=1\n"
+            )
+            cli.sendall(cmd.encode())
+            await asyncio.sleep(2)
+            resp = cli.recv(4096)
+            cli.close()
+            if b"SUCCESS" in resp:
+                self.logger.info(
+                    f"pullStream {stream_index} ({local_name}): OK"
+                )
+                self._stream_tasks[stream_index] = True
+                return
+            else:
+                self.logger.warning(
+                    f"pullStream {local_name} failed, falling back to FLV push"
+                )
+        except Exception as e:
+            self.logger.warning(
+                f"pullStream CLI unavailable ({e}), falling back to FLV push"
+            )
+
+        # Fallback: legacy ffmpeg + clock_sync + nc pipeline
         has_spawned = stream_index in self._ffmpeg_handles
         is_dead = has_spawned and self._ffmpeg_handles[stream_index].poll() is not None
 
         if not has_spawned or is_dead:
-            source = await self.get_stream_source(stream_index)
             cmd = (
                 "ffmpeg -nostdin -loglevel error -y"
                 f" {self.get_base_ffmpeg_args(stream_index)} -rtsp_transport"
@@ -934,12 +984,14 @@ class UnifiCamBase(metaclass=ABCMeta):
                 f" {self.get_extra_ffmpeg_args(stream_index)} -metadata"
                 f" streamName={stream_name} -f flv - | {sys.executable} -m"
                 " unifi.clock_sync"
-                f" {'--write-timestamps' if self._needs_flv_timestamps else ''} | nc"
-                f" {destination[0]} {destination[1]}"
+                f" {'--write-timestamps' if self._needs_flv_timestamps else ''}"
+                f" | nc {destination[0]} {destination[1]}"
             )
 
             if is_dead:
-                self.logger.warn(f"Previous ffmpeg process for {stream_index} died.")
+                self.logger.warn(
+                    f"Previous ffmpeg process for {stream_index} died."
+                )
 
             self.logger.info(
                 f"Spawning ffmpeg for {stream_index} ({stream_name}): {cmd}"


### PR DESCRIPTION
## Summary
- Fixes video streaming on UniFi Protect 7.x (7.0.x+) which broke the LiveFLV push pipeline
- Uses the ms binary's `pullStream` CLI command to have ms pull RTSP directly from the camera source
- Falls back to the legacy ffmpeg+clock_sync pipeline for older Protect versions

## Root Cause
Protect 7.x's ms binary (EvoStream v5.1.242) no longer reads `streamName` from FLV metadata to match incoming streams. Streams must be pre-created via the ms CLI `createIngestPoint`/`pullStream` commands. The ffmpeg → clock_sync → nc pipeline cannot work because the ms binary ignores all FLV data when no matching ingest point exists.

## How It Works
`start_video_stream()` now tries to connect to the ms binary's JSON CLI (port 1112) and sends a `pullStream` command to have ms pull RTSP directly from the camera source. This is the same mechanism ms uses for real UniFi cameras internally.

If the CLI connection fails (e.g. no SSH tunnel, or older Protect version), it falls back to the existing ffmpeg+clock_sync pipeline.

## Setup
Requires SSH tunnel to the NVR's ms CLI port (localhost-only):
```bash
ssh -L 1112:127.0.0.1:1112 root@<NVR_IP>
```

## Test Plan
- [x] Tested on UDM Pro Max, Protect 7.0.104
- [x] 8 cameras simultaneously with RTSP sources
- [x] Live view, recording, and snapshots working
- [x] Fallback to legacy pipeline when CLI unavailable
- [x] No regressions for existing functionality

Fixes #416